### PR TITLE
Fix trailing paren in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ plugin could look like this:
     vim.keymap.set('n', '<leader>Bf', function() file_history.files() end, { silent = true, desc = 'local history files in repo' })
     vim.keymap.set('n', '<leader>Bq', function() file_history.query() end, { silent = true, desc = 'local history query' })
   end
-})
+}
 ```
 
 


### PR DESCRIPTION
The provided lazy nvim snippet had a trailing paren and was thus invalid.