### PR TITLE
fix: avoid creating a backup for non-file buffers

### DIFF
--- a/lua/file_history/fh.lua
+++ b/lua/file_history/fh.lua
@@ -218,6 +218,11 @@ M.setup = function(opts)
   vim.api.nvim_create_autocmd({ "BufWritePost" }, {
     group = vim.api.nvim_create_augroup("file_history_group", { clear = true }),
     callback = function ()
+      -- ensure we don't try to back up special buffers like oil.nvim
+      if vim.bo.buftype ~= '' then
+        return
+      end
+
       FileHistory:backup_file(vim.fn.expand("%:p:h"), vim.fn.expand("%:t"))
     end,
   })


### PR DESCRIPTION
Whenever I tried to amend any change inside the oil.nvim buffer, I got an error like this:
<img width="1551" height="688" alt="Screenshot 2025-10-10 at 14 20 29" src="https://github.com/user-attachments/assets/207f0049-a020-4d67-9a97-d7925ac99d4c" />

Other users reported similar issues: https://github.com/stevearc/oil.nvim/issues/322

This was caused because the plugin was trying to create a backup of a non file buffer. Adding a simple check before calling the actual backup function, seems to solve the issue